### PR TITLE
revised linux installer to accept Logentries Account Key parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,3 +444,19 @@ Fields explained:
    main memory
 -  *vms* virtual memory size - the amount of virtual memory the process has
    allocated, including shared libraries
+
+Linux Agent (LE Agent) Installation
+-----------------------------------
+
+There are two ways to install the LE Agent.
+
+1.  NORMAL INTERACTIVE- Simply run `sudo bash logentries_install.sh`
+
+This will download and install the LE Agent on your machine and prompt you for your Logentries account email and Logentries account password.
+
+
+2. AUTOMATED, USING YOUR LOGENTRIES' ACCOUNT KEY - Run the Linux installer using your Logentries Account Key as the first command line arguemnt as in `sudo bash logentries_install.sh <account_key>` for example `sudo bash logentries_install.sh xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+
+This will bypass the prompts for your Email or password and simply download and install the LE Agent adding this Host and its Logs to your Account.  
+
+To attain your Logentries Account Key from the Logentries web UI see: https://logentries.com/doc/accountkey/

--- a/install/linux/logentries_install.sh
+++ b/install/linux/logentries_install.sh
@@ -82,6 +82,17 @@ declare -a LOGS_TO_FOLLOW=(
 /var/log/wtmp
 /var/log/faillog);
 
+# Test regex pattern against LE_ACCOUNT_KEY arg 1.
+regex_acct_key="[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$"
+if [ -n "$1" ] ; then
+	if [[ $1 =~ $regex_acct_key ]] ; then
+		printf "proceeding..."
+	else
+		printf "\nWrong format entered for account key.\nCorrect format is xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx ... Exiting installer\n\n"
+		exit 1
+	fi
+fi
+
 if [ -f /etc/le/config ]; then
 	printf "\n***** WARNING *****\n"
 	printf "It looks like you already have the Logentries agent registered on this machine\n"

--- a/install/mac/install.sh
+++ b/install/mac/install.sh
@@ -18,7 +18,7 @@ fi
 TMP_DIR=$(mktemp -d -t logentries.XXXXX)
 trap "rm -rf "$TMP_DIR"" EXIT
 
-FILES="le.py backports.py utils.py"
+FILES="le.py backports.py utils.py __init__.py metrics.py formatters.py"
 LE_PARENT="https://raw.githubusercontent.com/logentries/le/master/src/"
 CURL="/usr/bin/env curl -O"
 


### PR DESCRIPTION
Revised Linux LE installer to accept Account Key parameter in command line
Also simplifies interaction when installing and simply adds all logs to a Host.
Revised README.md file to document how to use this added functionality.