### PR TITLE
LOG-3424 Set FEAT_SSL_CONTEXT if we are on a newer version >= 2.7.9

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -51,7 +51,7 @@ try:
 
     wrap_socket = ssl.wrap_socket
     FEAT_SSL = True
-    FEAT_SSL_CONTEXT = 'create_default_context' in ssl.__dict__
+    FEAT_SSL_CONTEXT = sys.version_info >= (2, 7, 9)
 except ImportError:
     FEAT_SSL = False
     FEAT_SSL_CONTEXT = False


### PR DESCRIPTION
This should fix the registration issue on Ubuntu 14.10