### PR TITLE
Read tail of file line by line

### DIFF
--- a/src/le.py
+++ b/src/le.py
@@ -1334,7 +1334,7 @@ class Follower(object):
 
     def _read_log_line(self):
         """ Reads a line from the log. Checks maximal line size. """
-        buff = self._file.read(MAX_EVENTS)
+        buff = self._file.readline(MAX_EVENTS)
         return buff
 
     def _set_file_position(self, offset, start=FILE_BEGIN):


### PR DESCRIPTION
If the log file that is being monitored by the agent is updated much faster than the `TAIL_RECHECK` time, then any new entries are bundled together and sent as one entry.

This fix reads one line at a time, still adhering to the maximum event size.