### PR TITLE
Set default encoding to UTF-8 and change caching to contain the destination

### DIFF
--- a/src/formatters.py
+++ b/src/formatters.py
@@ -38,7 +38,7 @@ class FormatSyslog(object):
     def format_line(self, line, msgid='-', token=''):
         if not token:
             token = self._token
-        return '%s<14>1 %sZ %s %s - %s - hostname=%s appname=%s %s' % (
+        return '{}<14>1 {}Z {} {} - {} - hostname={} appname={} {}'.format(
                 token, datetime.datetime.utcnow().isoformat('T'),
                 self._hostname, self._appname,
                 msgid,

--- a/src/le.py
+++ b/src/le.py
@@ -2461,7 +2461,7 @@ def get_or_create_host(cache, host_name):
     return host_key
 
 
-def get_or_create_log(cache, host_key, log_name):
+def get_or_create_log(cache, host_key, log_name, destination):
     """ Gets or creates a log for the host given. It returns logs's token or
     None.
     """
@@ -2469,8 +2469,8 @@ def get_or_create_log(cache, host_key, log_name):
         return None
 
     # Find log in cache
-    if log_name in cache['log_tokens']:
-        return cache['log_tokens'][log_name]
+    if destination in cache['log_tokens']:
+        return cache['log_tokens'][destination]
 
     # Retrieve the log via API
     account_hosts = request_hosts(load_logs=True)
@@ -2486,7 +2486,7 @@ def get_or_create_log(cache, host_key, log_name):
 
     token = xlog.get('token', None)
     if token:
-        cache['log_tokens'][log_name] = token
+        cache['log_tokens'][destination] = token
     return token
 
 
@@ -2743,7 +2743,7 @@ def create_configured_logs(configured_logs):
             except ValueError:
                 log.error('Ignoring section %s since `%s\' does not contain host' % (clog.name, DESTINATION_PARAM))
             host_key = get_or_create_host(cache, hostname)
-            token = get_or_create_log(cache, host_key, logname)
+            token = get_or_create_log(cache, host_key, logname, clog.destination)
             if not token:
                 log.error('Ignoring section %s, cannot create log' % clog.name)
 

--- a/src/le.py
+++ b/src/le.py
@@ -1413,12 +1413,16 @@ class Follower(object):
         while not self._shutdown:
             try:
                 line = self._get_line()
+                if line:
+                    self._send_line(line)
             except IOError, e:
                 if config.debug:
                     log.debug("IOError: %s", e)
                 self._open_log()
-            if line:
-                self._send_line(line)
+            except UnicodeError, e:
+                log.warn("Error sending line %s", line, exc_info=True)
+            except Exception, e:
+		log.error("Caught unknown error %s while sending line: %s", e, line, exc_info=True)
         self._close_log()
 
 


### PR DESCRIPTION
Adjust default encoding to UTF-8, solving issues around handling non ascii/latin-1 characters.

The second commit changes the caching to include the whole destination in the token cache, as otherwhise two logs with different logset and same logname would go to the same log