### PR TITLE
Avoiding "Exception as e" for compatibility reasons

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -524,7 +524,7 @@ class Metrics(object):
         for x in self._items:
             try:
                 x.collect()
-            except Exception as e:
+            except Exception, e:
                 # Make sure we don't propagate any unexpected exceptions
                 # Typically `permission denied' on hard-ended systems
                 if self._debug:


### PR DESCRIPTION
Python versions <=2.4 don't understand "except .. as ...". Python 0.4 is still being used in CentOs5.