### PR TITLE
Update logentries_install.sh

### DIFF
--- a/install/linux/logentries_install.sh
+++ b/install/linux/logentries_install.sh
@@ -68,7 +68,7 @@ declare -a LOGS_TO_FOLLOW=(
 /var/log/auth.log
 /var/log/boot.log
 /var/log/daemon.log
-/var/log/dkpg.log
+/var/log/dpkg.log
 /var/log/kern.log
 /var/log/lastlog
 /var/log/mail.log


### PR DESCRIPTION
Fixed typo in line 71. Followed log should be /var/log/dpkg.log, not /var/log/dkpg.log.