### PR TITLE
- Tail file as block (up to MAX_EVENTS) + give the same filter's flexibility to formatters

### DIFF
--- a/src/.#le.py
+++ b/src/.#le.py
@@ -1,1 +1,0 @@
-marc@Marcs-MacBook-Pro.local.4791

--- a/src/.#le.py
+++ b/src/.#le.py
@@ -1,0 +1,1 @@
+marc@Marcs-MacBook-Pro.local.4791

--- a/src/formatters.py
+++ b/src/formatters.py
@@ -19,7 +19,10 @@ class FormatPlain(object):
         self._token = token
 
     def format_line(self, line):
-        return self._token + line
+        lines = []
+        for l in filter(None, line.split("\n")):
+            lines.append(self._token + l)
+        return (''.join(x+"\n" for x in lines))
 
 
 class FormatSyslog(object):
@@ -38,7 +41,12 @@ class FormatSyslog(object):
     def format_line(self, line, msgid='-', token=''):
         if not token:
             token = self._token
-        return '{token}<14>1 {dt}Z {hostname} {appname} - {msgid} - hostname={hostname} appname={appname} {line}'.format(
-            token=token, dt=datetime.datetime.utcnow().isoformat('T'),
-            hostname=self._hostname, appname=self._appname,
-            msgid=msgid, line=line)
+        lines = []
+        for l in filter(None, line.split("\n")):
+            lines.append(
+                '{token}<14>1 {dt}Z {hostname} {appname} - {msgid} - hostname={hostname} appname={appname} {line}'.format(
+                    token=token, dt=datetime.datetime.utcnow().isoformat('T'),
+                    hostname=self._hostname, appname=self._appname,
+                    msgid=msgid, line=l)
+            )
+        return (''.join(x+"\n" for x in lines))


### PR DESCRIPTION
* The first commit will rollback to tailing block by block. If we happen to read a line in a middle, it is keep for the next read and then prepended.
  * Require modification in the formatter since a block of lines is pass as arguments.
  * Allow multi-line log to be correctly handle by filters and formatters
  * May improve performance
* The second commit give the same filter's flexibility to formatters.
  * Read https://logentries.com/doc/linux-agent/#sensitive_data and replace filters by formatters should work
     * Formatters path can be given in the config file with "formatters"
     * The name of the file must be user_formatters.py (formatters is already used)
     * The name of the variable holding the formatters hashtable is "formatters"
  * Do no replace the "formatter" keyword in config. It will be use as default if user define formatter cannot fund
  * New import: `from functools import partial`. Not specially required but better for code clarity.

Cheers