### PR TITLE
Add "custom-format" config setting in the [Main] block

### DIFF
--- a/src/formatters.py
+++ b/src/formatters.py
@@ -42,3 +42,33 @@ class FormatSyslog(object):
             token=token, dt=datetime.datetime.utcnow().isoformat('T'),
             hostname=self._hostname, appname=self._appname,
             msgid=msgid, line=line)
+
+
+class FormatCustom(object):
+
+    """Formats lines according to the supplied format string. Hostname is taken
+    from configuration or current hostname is used. The supported variables
+    in the format string are as follows:
+
+    {isodatetime}: current ISO-8601-formatted date/time in UTC timezone,
+    e.g. "2015-08-11T13:10:09.320514".
+    {hostname}: taken from config, or current hostname is used.
+    {appname}: the current application name.
+    {line}: the log line."""
+
+    def __init__(self, format, hostname, appname, token):
+       self._format = format
+        if hostname:
+            self._hostname = hostname
+        else:
+            self._hostname = socket.gethostname()
+        self._appname = appname
+        self._token = token
+
+    def format_line(self, line):
+        return self._token + self._format.format(
+            isodatetime=datetime.datetime.utcnow().isoformat('T'),
+            hostname=self._hostname,
+            appname=self._appname,
+            line=line.rstrip('\n')) + '\n'
+

--- a/src/formatters.py
+++ b/src/formatters.py
@@ -57,7 +57,7 @@ class FormatCustom(object):
     {line}: the log line."""
 
     def __init__(self, format, hostname, appname, token):
-       self._format = format
+        self._format = format
         if hostname:
             self._hostname = hostname
         else:

--- a/src/le.py
+++ b/src/le.py
@@ -37,6 +37,7 @@ USER_KEY_PARAM = 'user-key'
 AGENT_KEY_PARAM = 'agent-key'
 FILTERS_PARAM = 'filters'
 FORMATTER_PARAM = 'formatter'
+CUSTOM_FORMAT_PARAM = 'custom-format'
 SUPPRESS_SSL_PARAM = 'suppress_ssl'
 USE_CA_PROVIDED_PARAM = 'use_ca_provided'
 FORCE_DOMAIN_PARAM = 'force_domain'
@@ -1687,6 +1688,7 @@ class Config(object):
         self.daemon = False
         self.filters = NOT_SET
         self.formatter = NOT_SET
+        self.custom_format = NOT_SET
         self.force = False
         self.hostname = NOT_SET
         self.name = NOT_SET
@@ -1776,6 +1778,7 @@ class Config(object):
                 AGENT_KEY_PARAM: '',
                 FILTERS_PARAM: '',
                 FORMATTER_PARAM: '',
+                CUSTOM_FORMAT_PARAM: '',
                 SUPPRESS_SSL_PARAM: '',
                 FORCE_DOMAIN_PARAM: '',
                 USE_CA_PROVIDED_PARAM: '',
@@ -1803,6 +1806,10 @@ class Config(object):
                 new_formatter = conf.get(MAIN_SECT, FORMATTER_PARAM)
                 if new_formatter != '':
                     self.formatter = new_formatter
+            if self.custom_format == NOT_SET:
+                new_custom_format = conf.get(MAIN_SECT, CUSTOM_FORMAT_PARAM)
+                if new_custom_format != '':
+                    self.custom_format = new_custom_format
             if self.hostname == NOT_SET:
                 self.hostname = conf.get(MAIN_SECT, HOSTNAME_PARAM)
                 if not self.hostname:
@@ -1889,6 +1896,8 @@ class Config(object):
                 conf.set(MAIN_SECT, FILTERS_PARAM, self.filters)
             if self.formatter != NOT_SET:
                 conf.set(MAIN_SECT, FORMATTER_PARAM, self.formatter)
+            if self.custom_format != NOT_SET:
+                conf.set(MAIN_SECT, CUSTOM_FORMAT_PARAM, self.custom_format)
             if self.hostname != NOT_SET:
                 conf.set(MAIN_SECT, HOSTNAME_PARAM, self.hostname)
             if self.suppress_ssl:
@@ -2701,7 +2710,9 @@ def start_followers(default_transport):
             log.info("Following %s", log_filename)
 
             if log_token or config.datahub:
-                if config.formatter == 'plain':
+                if config.custom_format != NOT_SET:
+                    formatter = formatters.FormatCustom(config.custom_format, config.hostname, log_name, log_token)
+                elif config.formatter == 'plain':
                     formatter = formatters.FormatPlain(log_token)
                 elif config.formatter == 'syslog' or config.formatter == NOT_SET:
                     formatter = formatters.FormatSyslog(config.hostname, log_name, log_token)

--- a/src/le.py
+++ b/src/le.py
@@ -2710,7 +2710,7 @@ def start_followers(default_transport):
             log.info("Following %s", log_filename)
 
             if log_token or config.datahub:
-                if config.custom_format != NOT_SET:
+                if config.formatter == 'custom':
                     formatter = formatters.FormatCustom(config.custom_format, config.hostname, log_name, log_token)
                 elif config.formatter == 'plain':
                     formatter = formatters.FormatPlain(log_token)


### PR DESCRIPTION
As discussed in https://support.logentries.com/hc/en-us/requests/8037 .  Formats lines according to the supplied format string. Hostname is taken from configuration or current hostname is used. The supported variables in the format string are as follows:

    {isodatetime}: current ISO-8601-formatted date/time in UTC timezone, e.g. "2015-08-11T13:10:09.320514".
    {hostname}: taken from config, or current hostname is used.
    {appname}: the current application name.
    {line}: the log line.

This takes precedence over the "formatter" setting.

We're now using this:

```
custom-format = {line} [host={hostname}]
```

And the resulting logs look like:

```
2015-08-14 11:20:43,699 [Writeout Job for Game 668] INFO  WriteoutSchedule  - Timeseries type Timeseries Type NORMAL: EVENTS_HIT_ROLLUPS scheduled for 2015-08-14T11:20:45.698Z [host=eventprocessor-1.featurestack15.swrve.com] featurestack15/eventprocessor-1
2015-08-14 11:20:43,699 [Writeout Job for Game 668] INFO  WriteoutSchedule  - Timeseries type Timeseries Type ABTEST: ATTRIBUTE_HISTOGRAMS scheduled for 2015-08-14T11:20:45.698Z [host=eventprocessor-1.featurestack15.swrve.com] featurestack15/eventprocessor-1
```