### PR TITLE
install python formats for Mac users

### DIFF
--- a/install/mac/install.sh
+++ b/install/mac/install.sh
@@ -44,6 +44,9 @@ done
 $CURL $DAEMON_DL_LOC
 sed -i -e 's/python2/python/' *.py
 
+printf "Installing Python dependencies"
+pip install formats
+
 printf "Copying files...\n"
 mkdir -p "$INSTALL_DIR"/logentries || true
 mv *.py "$INSTALL_DIR"/logentries


### PR DESCRIPTION
Install python formats as it is a required dependency 