### PR TITLE
Update install to latest Logentries and SmartOS base image

### DIFF
--- a/install/smartos/install.sh
+++ b/install/smartos/install.sh
@@ -1,28 +1,94 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-echo "Logentries Agent Installer for Joyent SmartOS\n"
+#############################################
+#
+#       Quickstart Agent Installer
+#       Author: Stephen Hynes, Charles Phillips
+#       Version: 1.0
+#
+#############################################
 
-if [ ! -x "/opt/local/bin/python2.7" ]; then
-	echo "You need to install python2.7 package to run this agent, Try using 'pkgin install python27'.\n"
-  exit 0
+# Need root to run this script
+if [ "$(id -u)" != "0" ]; then
+    echo "Please run this  script as root."
+    echo "Usage: sudo ./install.sh"
+    exit 1
 fi
 
-#Create directories
-mkdir -p /opt/local/lib/svc/method
-mkdir -p /opt/local/lib/svc/manifest/system
+TMP_DIR=$(mktemp -d -t logentries.XXXXX)
+trap "rm -rf "$TMP_DIR"" EXIT
 
-echo "Downloading files..."
-#Download files
-wget --no-check-certificate -q -O /opt/local/bin/le https://raw.githubusercontent.com/logentries/le/b88308c21c3182084020f8fb2413aefac93c172a/le
-wget --no-check-certificate -q -O /opt/local/lib/svc/method/svc-logentries https://raw.github.com/logentries/le/master/install/smartos/svc-logentries
-wget --no-check-certificate -q -O /opt/local/lib/svc/manifest/system/logentries.xml https://raw.github.com/logentries/le/master/install/smartos/logentries.xml
+FILES="le.py backports.py utils.py __init__.py metrics.py formats.py"
+LE_PARENT="https://raw.githubusercontent.com/logentries/le/master/src/"
+CURL="/usr/bin/env curl -O"
 
-#Make executables
-chmod +x /opt/local/bin/le
-chmod +x /opt/local/lib/svc/method/svc-logentries
+SMARTOS_INSTALL="https://raw.githubusercontent.com/logentries/le/master/install/smartos/"
+INSTALL_DIR="/opt/local/lib/logentries"
+LOGGER_CMD="logger -t LogentriesTest Test Message Sent By LogentriesAgent"
+DAEMON="svc-logentries"
+DAEMON_DL_LOC="$SMARTOS_INSTALL$DAEMON"
+DAEMON_PATH="/opt/local/lib/svc/method/$DAEMON"
+
+SMF_CONFIG="logentries.xml"
+SMF_CONFIG_DL_LOC="$SMARTOS_INSTALL$SMF_CONFIG"
+SMF_CONFIG_PATH="/opt/local/lib/svc/manifest/$SMF_CONFIG"
+
+INSTALL_PATH="/opt/local/bin/le"
+REGISTER_CMD="$INSTALL_PATH register"
+LE_FOLLOW="$INSTALL_PATH follow"
+
+printf "Welcome to the Logentries Install Script\n"
+
+printf "Downloading dependencies...\n"
+
+cd "$TMP_DIR"
+for file in $FILES ; do
+  echo $file
+  $CURL $LE_PARENT/$file
+done
+
+$CURL $DAEMON_DL_LOC
+$CURL $SMF_CONFIG_DL_LOC
+sed -i -e 's/python2/python/' *.py
+
+printf "Copying files...\n"
+mkdir -p "$INSTALL_DIR"/logentries || true
+mv *.py "$INSTALL_DIR"/logentries
+chown -R root:root "$INSTALL_DIR"
+chmod +x "$INSTALL_DIR"/logentries/le.py
+chown root:root $DAEMON
+mv $DAEMON $DAEMON_PATH
+chmod +x $DAEMON_PATH
+rm -f "$INSTALL_PATH" || true
+ln -s "$INSTALL_DIR"/logentries/le.py "$INSTALL_PATH" 2>/dev/null || true
+mv $SMF_CONFIG $SMF_CONFIG_PATH
 
 echo "Adding logentries agent to svcadm  (Services)"
 #Add logentries agent to the services
-svccfg import /opt/local/lib/svc/manifest/system/logentries.xml
+svccfg import $SMF_CONFIG_PATH
 
-echo "Installation Complete\n"
+$REGISTER_CMD
+$LE_FOLLOW "/var/log/syslog"
+
+printf "\n**** Install Complete! ****\n\n"
+printf "If you would like to monitor more files, simply run this command as root, 'le follow filepath', e.g. 'le follow /var/log/mylog.log'\n\n"
+printf "And be sure to restart the agent service for new files to take effect, you can do this with the following two commands.\n"
+printf "svcadm disable logentries\n"
+printf "svcadm enable logentries\n"
+printf "For a full list of commands, run 'le --help' in the terminal.\n\n"
+
+svcadm disable logentries
+svcadm enable logentries
+
+printf "Starting agent"
+i="0"
+while [ $i -lt 40 ]
+do
+    sleep 0.05
+    printf "."
+    i=$[$i+1]
+done
+
+printf "DONE\n"
+
+exit 0


### PR DESCRIPTION
Previous SmartOS install script was for Logentries 1.3.0, two years old.  This install script is a merge of the current OSX install script with the old SmartOS install script.

The current Joyent SmartOS base image (15.3.0) contains Python 2.7.9.  SmartOS base images 14.3.0 and older only reach Python 2.7.8, which has an SSL module too old for Logentries.

Since current Logentries uses `psutil` for metrics, this might fix #60. (After installing `pip` and installing and symlinking `gcc` I am able to get `psutil` to build/install and Logentries Agent is sending metrics.)