### PR TITLE
Avoid cache when server side configuration is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ of `host name/log name'. The agent will search for the host and log identified
 by their name and retrieve the token automatically. If the host or log does not
 exist, it is created.
 
-**Note**: When using the destination parameter it is advised not to initialize multiple agents
-with the same configuration file at the same time. This is to prevent a race condition where
-duplicate Log Sets may be created.
+**Note**: When using the destination parameter it is advised not to initialize
+multiple agents with the same configuration file at the same time. This is to
+prevent a race condition where duplicate Log Sets may be created.
 
 Example:
 
@@ -210,8 +210,8 @@ Example:
 Using local configuration only
 ------------------------------
 
-In an auto scaling environment you may not want to create a Host each time you
-install the agent.
+In an auto scaling environment you may not want to create a Host (log set) each
+time you install the agent.
 
 To disable pulling server-side configuration (and thus avoiding communication
 with Logentries API) add this line in the `[Main]` section of the configuration:
@@ -223,7 +223,14 @@ or `reinit` commands:
 
 	sudo le reinit --pull-server-side-config=False
 
-By default, locally configured logs are sent to Logentries in Syslog format RFC 5424 which prepends a timestamp and other useful information. If you wish to disable this, you can set the formatter to 'plain' in the `[Main]` section of the configuration.
+When set to False, the agent requires token for all configured logs. Tokens may
+be specified in the configuration file, or--in case of logs created by the
+agent--it is stored in local cache file.
+
+By default, locally configured logs are sent to Logentries in Syslog format RFC
+5424 which prepends a timestamp and other useful information. If you wish to
+disable this, you can set the formatter to 'plain' in the `[Main]` section of
+the configuration.
 
 	formatter = plain
 

--- a/src/le.py
+++ b/src/le.py
@@ -2767,9 +2767,11 @@ def get_cache_filename():
     return os.path.join(cache_dir, CACHE_NAME)
 
 
-def load_cache():
+def load_cache(empty=False):
     """Loads or creates cache.
     """
+    if empty:
+        return {'host_keys':{}, 'log_tokens':{}}
     cache_filename = get_cache_filename()
     try:
         if os.path.exists(cache_filename):
@@ -3183,7 +3185,8 @@ def create_configured_logs(configured_logs):
     """ Get tokens for all configured logs. Logs with no token specified are
     retrieved via API and created if needed.
     """
-    cache = load_cache()
+    # Load loca cache unless we are allowed to load server side configuration
+    cache = load_cache(config.pull_server_side_config)
     for clog in configured_logs:
         if not clog.destination and not clog.token:
             log.error('Ignoring section %s as neither %s nor %s is specified', clog.name, TOKEN_PARAM, DESTINATION_PARAM)
@@ -3200,7 +3203,8 @@ def create_configured_logs(configured_logs):
                 log.error('Ignoring section %s, cannot create log' % clog.name)
 
             clog.token = token
-    save_cache(cache)
+    if not config.pull_server_side_config:
+        save_cache(cache)
 
 
 def cmd_monitor(args):


### PR DESCRIPTION
The local cache was causing issues when users removed and re-created the destination host. Token has changed but the agent used old ones.