### PR TITLE
Remove explicit hostname and appname from default format

### DIFF
--- a/src/formats.py
+++ b/src/formats.py
@@ -37,12 +37,10 @@ class FormatSyslog(object):
     def format_line(self, line, msgid='-', token=None):
         if not token:
             token = self._token
-        return '%s<14>1 %sZ %s %s - %s - hostname=%s appname=%s %s'%(
+        return '%s<14>1 %sZ %s %s - %s - %s'%(
             token, datetime.datetime.utcnow().isoformat('T'),
             self._hostname, self._appname,
-            msgid,
-            self._hostname, self._appname,
-            line)
+            msgid, line)
 
 
 class FormatCustom(object):

--- a/test/tests.d/entry_identifier.py
+++ b/test/tests.d/entry_identifier.py
@@ -29,13 +29,13 @@ LE_PID=$!
 sleep 1
 echo 'First message' >> example.log
 echo 'Second message' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web First message
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web Second message
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - First message
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - Second message
 sleep 1
 echo 'Third message' >> example.log
 echo 'Fourth message' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web Third message
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web Fourth message
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - Third message
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - Fourth message
 sleep 1
 
 kill $LE_PID
@@ -74,13 +74,13 @@ echo 'Line 1' >> example.log
 echo 'separatorLine 2' >> example.log
 echo 'Line 3' >> example.log
 echo 'Line 4' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web separatorLine 0 Line 1
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web separatorLine 2 Line 3 Line 4
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - separatorLine 0 Line 1
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - separatorLine 2 Line 3 Line 4
 sleep 1
 echo 'Line 5' >> example.log
 echo 'separatorLine 6' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web Line 5
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web separatorLine 6
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - Line 5
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - separatorLine 6
 sleep 1
 
 kill $LE_PID
@@ -126,8 +126,8 @@ echo 'separatorLine 0' >> example.log
 echo 'Line 1' >> example.log
 echo 'separatorLine 2' >> example.log
 echo 'Line 3' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web separatorLine 0 Line 1
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web separatorLine 2 Line 3
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - separatorLine 0 Line 1
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - separatorLine 2 Line 3
 sleep 1
 
 kill $LE_PID
@@ -162,8 +162,8 @@ echo 'separatorLine 0' >> example.log
 echo 'Line 1' >> example.log
 echo 'separatorLine 2' >> example.log
 echo 'Line 3' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web separatorLine 0 Line 1
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web separatorLine 2 Line 3
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - separatorLine 0 Line 1
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - separatorLine 2 Line 3
 sleep 1
 
 kill $LE_PID
@@ -199,8 +199,8 @@ echo 'abrakaLine 0' >> example.log
 echo 'dabraLine 1' >> example.log
 echo 'abrakaLine 2' >> example.log
 echo 'dabraLine 3' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web abrakaLine 0 dabraLine 1
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web abrakaLine 2 dabraLine 3
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - abrakaLine 0 dabraLine 1
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - abrakaLine 2 dabraLine 3
 sleep 1
 
 kill $LE_PID

--- a/test/tests.d/formatters.sh
+++ b/test/tests.d/formatters.sh
@@ -47,9 +47,9 @@ LE_PID=$!
 
 sleep 1
 echo 'First message' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web First message
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - First message
 echo 'Second message' >> example.log
-#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - hostname=myhost appname=Web Second message
+#e 89caf699-8fb7-45b1-a41f-ae111ec99148<14>1 ISODATETIME myhost Web - - - Second message
 sleep 1
 
 kill $LE_PID
@@ -76,9 +76,9 @@ LE_PID=$!
 
 sleep 1
 echo 'First message' >> example.log
-#e <14>1 ISODATETIME myhost Log_name_0 - - - hostname=myhost appname=Log_name_0 First message
+#e <14>1 ISODATETIME myhost Log_name_0 - - - First message
 echo 'Second message' >> example.log
-#e <14>1 ISODATETIME myhost Log_name_0 - - - hostname=myhost appname=Log_name_0 Second message
+#e <14>1 ISODATETIME myhost Log_name_0 - - - Second message
 sleep 1
 
 kill $LE_PID


### PR DESCRIPTION
By default the agent adds explicit hostname and appname fields in every entry. That's not needed anymore since the backend understands syslog structure automatically and these fields are available in flat as well as keyspaced form.