### PR TITLE
Add socks.py from #165 to fix ImportError line 264

### DIFF
--- a/install/smartos/install.sh
+++ b/install/smartos/install.sh
@@ -18,7 +18,7 @@ fi
 TMP_DIR=$(mktemp -d -t logentries.XXXXX)
 trap "rm -rf "$TMP_DIR"" EXIT
 
-FILES="le.py backports.py utils.py __init__.py metrics.py formats.py"
+FILES="le.py backports.py utils.py __init__.py metrics.py formats.py socks.py"
 LE_PARENT="https://raw.githubusercontent.com/logentries/le/master/src/"
 CURL="/usr/bin/env curl -O"
 


### PR DESCRIPTION
Looks like #165 added the socks.py dependency, so we need it in the install script.

Thanks!