### PR TITLE
Log-7549 and LOG-7550 Linux Agent Stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ infrastructure.
   * [Using local configuration only](#using-local-configuration-only)
   * [List IP addresses the agent uses](#list-ip-addresses-the-agent-uses)
   * [Follow logs that change their names](#follow-logs-that-change-their-names)
+  * [Follow a log that appears across multiple directories](#follow-a-log-that-appears-across-multiple-directories)
   * [Manipulate your data in transit](#manipulate-your-data-in-transit)
   * [Format output entries](#format-output-entries)
   * [Filtering file names](#filtering-file-names)
@@ -66,6 +67,7 @@ How to use
 	--suppress-ssl    do not use SSL with API server
 	--yes	          always respond yes
 	--pull-server-side-config=False do not use server-side config for following files
+	--multilog        option used with directory wildcard (restricted behaviour - see below for details)
 
 
 Repositories
@@ -262,6 +264,116 @@ for any active log in the folder and will monitor the events in that log.
 log file named `xxx.log` is renamed to `xxx.log.0` and a new `xxx.log` file is
 created. In this situation follow the `xxx.log` file only, do not specify
 wildcards.
+
+Follow a log that appears across multiple directories
+-----------------------------------------------------
+When using the 'follow' command to set up which log file to be followed, a special
+wildcard with restricted behaviour can be used for (or as part of) a directory 
+name. This option is intended for where multiple log files, with the same filename 
+but with each log file in a different directory, are to be followed. The log 
+events captured in all these log files are then sent to a single destination log in 
+the Logentries infrastructure. Note that this behaviour is different from where
+a wildcard is used in the log filename - which is not allowed in this case.
+
+Example:
+For this example there is a number of directories in /var/log/, each called 'apache-xx',
+where the xx is a number that varies for each directory, such as 'apache-01', 
+'apache-02' and so on. In addition, within each directory, is a file called 'apache.log'.
+
+We want to follow all 'apache.log' files in each of these directories, with the log
+events from all log files sent to a destination log in the Logentries infrastructure 
+that we want to name 'Apache'.
+
+The command 'follow' is combined with the '--multilog' option to use the wildcard 
+in the directory name in the path that is passed to the agent.
+  
+    le follow '/var/log/apache-*/apache.log' --multilog [--name Apache]
+
+#### Usage
+The agent behaviour when usage of the --multilog is made is dependant on
+the rules below: 
+
+-   The pathname to be passed to the agent must be in single quotes as shown
+    in the example. This is necessary, so that the wildcard is not expanded 
+    by the shell, but processed by the agent internally. 
+-   The wildcard * is the only one allowed for this behaviour.
+-   Only one wildcard is allowed in the pathname.
+-   The wildcard can be used in place of a directory name or in place of part 
+    of a directory name.
+-   At all times a full filename must be given.
+-   No wildcard is allowed in the filename.
+-   Only the one file in each directory found that matches the pattern with 
+    the wildcard is followed.
+-   The wildcard is not required, but then only a single file is followed. 
+    In such a case, the --multilog option is unnecessary as the default 
+    behaviour of the 'follow' command can be used to follow a single file.
+-   Where the --name is not used, the filename is used to name the destination
+    log - which in the case of the example above is 'apache.log'
+-   The agent expects the last / as being followed by a filename - it cannot
+    be blank - the log filename does not need to have an extension such 
+    as .log; a log file named 'apache', such as '/var/log/apache*/apache' 
+    is accepted - as long as it is a full and valid filename.
+
+#### Displayed Lists
+If the pathname with the wildcard is valid and accepted by the agent, it will 
+display to the user two lists that are shown as an aid to help the user
+make the most of the wildcard usage.
+
+The first list will display all the existing destination logs for that host found 
+in use from the server with the pathname of the local log file (or files) associated
+with each log. Where there is a log with a pathname that was set up using the --multilog 
+option a prefix to the pathname 'Multiple:' is shown. This list may show a mix of pathnames - 
+as some will have been set-up using the --mulitlog option and some not.
+
+So as per the example above, for the log 'Apache', may return a list like this:
+
+    LOG         PATHNAME
+    mylog       /var/log/mysystem/mylog-*.log      
+    Apache      Multiple:/var/log/apache*/apache.log
+    Cassandra   /srv/log/cassandra/system.out
+
+The second list will display any files found by the agent at this time after 
+processing the pathname that fall within the scope of the wildcard. This list
+reflects the files that will be followed by the agent for this pathname however,
+the files actually followed may differ if directories are deleted or added 
+before the agent has been restarted or is actively monitoring the log files. 
+
+The agent will detect where directories that have a file being followed
+is deleted, and will stop following that file. Like wise the agent will monitor
+for directories with a file that falls within the scope of the wildcard expansion.
+If such a directory is created while the agent is active, it will attempt to 
+follow this new file - with the same log settings.
+
+The user then has the option to quit without setting any new files to be followed
+or the user may continue, in which case the agent will process the pathname.
+
+**Note** that there is no restriction on different destination logs having pathnames
+with wildcards that are similar. It is possible therefore that a number of files
+will appear to be common to these destination logs. The agent will not prevent this.
+It is dependant on the user to understand the scope of the wildcard in the pathname
+that is being applied.
+
+For example the following two examples result in a subset of directories with the
+same log file falling within the scope of both destination directories:
+  
+    le follow '/var/log/apache*/apache.log' --multilog --name=Apace
+    le follow '/var/log/*/apache.log' --multilog --name=WebLogs
+  
+It is recommended to avoid scenarios like this.
+
+### Client Configuration File
+As explained above in the section on using the client side configuration to 
+follow files, a similar configuration section can used to set up a pathname
+with a wildcard - as long as the pathname meets the same rules for one 
+entered via the command line.
+ 
+The prefix Multilog: is mandatory.
+
+Example: 
+
+    [Apache]
+	path = Multilog:/var/log/apache*/current
+	token = MY_TOKEN
 
 
 Manipulate your data in transit

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ How to use
 	follow <filename>  Follow the given log
 	--name=  name of the log
 	--type=  type of the log
+	--multilog option used with directory wildcard (restricted behaviour - see below for details)
 	followed <filename>  Check if the file is followed
 	clean     Removes configuration file
 	ls        List internal filesystem and settings: <path>
@@ -67,7 +68,6 @@ How to use
 	--suppress-ssl    do not use SSL with API server
 	--yes	          always respond yes
 	--pull-server-side-config=False do not use server-side config for following files
-	--multilog        option used with directory wildcard (restricted behaviour - see below for details)
 
 
 Repositories

--- a/src/le.py
+++ b/src/le.py
@@ -80,6 +80,21 @@ EMBEDDED_STRUCTURES = {
     "http": "803fe7ba-bd2e-44bd-8ee7-f02fa253ef5f",
 }
 
+# '--multilog' option related
+# max number of files that are allowed to be followed at any one time 
+MAX_FILES_FOLLOWED = 100
+# prefix used to distinguish pathnames in config or server side
+# as intended for mutlilog behaviour
+PREFIX_MULTILOG_FILENAME = "Multilog:"
+# time interval to retry glob of multilog pathname to catch any 
+# change in relevant directories that may have been deleted or added
+RETRY_GLOB_INTERVAL = 0.250 # in seconds 
+
+# intervals for .join() on several threads
+FOLLOWMULTI_JOIN_INTERVAL = 1.0  # in seconds
+FOLLOWER_JOIN_INTERVAL = 1.0    # in seconds
+TRANSPORT_JOIN_INTERVAL = 1.5   # in seconds
+
 
 class Domain(object):
 
@@ -210,6 +225,19 @@ Where parameters are:
                           the format is address:port with port being optional
   --system-stat-token=    set the token for system stats log (beta)
   --pull-server-side-config=False do not use server-side config for following files
+  --multilog              option used with directory wildcard * (restricted behaviour)
+"""
+
+# multilog option usage
+MULTILOG_USAGE = \
+"""
+Usage:
+  Agent is expecting a path name for a file, which should be between single quotes:
+        example: \'/var/log/directoryname/file.log\'
+  A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+  Wildcard can not be used for expansion of filename, but for directory name only.
+  Place path name with wildcard between single quotes:
+        example: \"/var/log/directory*/file.log\"
 """
 
 
@@ -1461,6 +1489,100 @@ class Stats(object):
         if self.timer:
             self.timer.cancel()
 
+class FollowMultilog(object):
+    """
+    The FollowMultilog is responsible for handling those logs that were set-up using the
+    '--multilog' option and that may have a wildcard in the pathname.
+    In which case multiple local (log) files will be followed, but with all the new events
+    from all the files forwarded to the same single log in the logentries infrastructure.
+    """
+
+    def __init__(self, name, entry_filter, entry_formatter, entry_identifier, transport, max_num_followers=MAX_FILES_FOLLOWED ):
+        """ Initializes the FollowMultilog. """
+        self.name = name
+        self.flush = True
+        self.entry_filter = entry_filter
+        self.entry_formatter = entry_formatter
+        self.entry_identifier = entry_identifier
+        self.transport = transport
+
+        self._shutdown = False
+        self._max_num_followers=max_num_followers
+        self._followers = []
+        self._worker = threading.Thread(
+            target=self.supervise_followers, name=self.name)
+        self._worker.daemon = True
+        self._worker.start()
+
+    def _file_test(self, candidate):
+        """
+        Only regular files passed
+        """
+        # fail if a symbolic link
+        if os.path.islink(candidate):
+            return False
+        # fail if not a regular file (passes links!)
+        if not os.path.isfile(candidate):
+            return False
+        return True
+    
+    def _append_followers(self, add_files):
+        
+        for filename in add_files:
+            if len(self._followers) < self._max_num_followers:        
+                follower = Follower(filename, self.entry_filter, self.entry_formatter, self.entry_identifier, self.transport, True)
+                self._followers.append(follower)
+                if config.debug_multilog:
+                    print >> sys.stderr, "Number of followers increased to: %s " %len(self._followers)
+            else:
+                log.debug("Warning: Allowed maximum of files that can be followed reached")
+                break
+                        
+    def _remove_followers(self, removed_files):
+        
+        for follower in self._followers:
+            if follower.name in removed_files:                
+                follower.close()
+                self._followers.remove(follower)
+                if config.debug_multilog:
+                    print >> sys.stderr, "Number of followers decreased to: %s " %len(self._followers)
+                
+    def close(self):
+        """
+        Stops all FollowMultilog activity, and then loops through list of existing
+        followers to close each one - then waits for the worker thread to stop.
+        """
+        self._shutdown = True
+        #run through list of followers closing each one
+        for follower in self._followers:
+            follower.close()
+        self._worker.join(FOLLOWMULTI_JOIN_INTERVAL)
+        
+    def supervise_followers(self):
+        """
+         Instantiates a Follower object for each file found - all log events from all
+         files are forwarded to the same log in the lE infrastructure
+        """ 
+        try:
+            start_set = set([filename for filename in glob.glob(self.name)])         
+        except os.error:
+            log.error("Error: FollowerMultiple glob has failed")
+        if len(start_set) == 0:
+            log.error("FollowMultilog: no files found in OS to be followed")
+        else:
+            self._append_followers(start_set)
+        while not self._shutdown:
+            time.sleep(RETRY_GLOB_INTERVAL)
+            try:
+                current_set = set([filename for filename in glob.glob(self.name)])                
+            except os.error:
+                log.error("Error: FollowerMultiple glob has failed")
+            followed_files = [follower.name for follower in self._followers]
+            added_files = [filename for filename in current_set if not filename in followed_files]            
+            self._append_followers(added_files)                
+            removed_files = [filename for filename in followed_files if not filename in current_set]
+            self._remove_followers(removed_files)
+                                          
 
 class Follower(object):
 
@@ -1468,7 +1590,7 @@ class Follower(object):
     The follower keeps an eye on the file specified and sends new events to the
     logentries infrastructure.  """
 
-    def __init__(self, name, entry_filter, entry_formatter, entry_identifier, transport):
+    def __init__(self, name, entry_filter, entry_formatter, entry_identifier, transport, disable_glob=False):
         """ Initializes the follower. """
         self.name = name
         self.flush = True
@@ -1476,6 +1598,8 @@ class Follower(object):
         self.entry_formatter = entry_formatter
         self.entry_identifier = entry_identifier
         self.transport = transport
+        # FollowMultilog usage
+        self._disable_glob = disable_glob
 
         self._file = None
         self._shutdown = False
@@ -1511,7 +1635,12 @@ class Follower(object):
         self.real_name = None
 
         while not self._shutdown:
-            candidate = self._file_candidate()
+
+            # FollowMultilog usage
+            if self._disable_glob:
+                candidate = self.name
+            else:
+                candidate = self._file_candidate()
 
             if candidate:
                 self.real_name = candidate
@@ -1680,7 +1809,7 @@ class Follower(object):
         """Closes the follower by setting the shutdown flag and waiting for the
         worker thread to stop."""
         self._shutdown = True
-        self._worker.join(1.0)
+        self._worker.join(FOLLOWER_JOIN_INTERVAL)
 
     def monitorlogs(self):
         """ Opens the log file and starts to collect new events. """
@@ -1904,7 +2033,7 @@ class Transport(object):
 
     def close(self):
         self._shutdown = True
-        self._worker.join(1.5)
+        self._worker.join(TRANSPORT_JOIN_INTERVAL)
 
     def run(self):
         """When run with backgroud thread it collects entries from internal
@@ -2023,6 +2152,8 @@ class Config(object):
         self.uuid = False
         self.xlist = False
         self.yes = False
+        self.multilog = False
+        # Behaviour associated with daemontools/multilog
 
         #proxy
         self.use_proxy = NOT_SET
@@ -2034,6 +2165,10 @@ class Config(object):
 
         # Enabled fine-grained logging
         self.debug = False
+        # Command line args to stderr
+        self.debug_cmd_line = False
+        # Multilog specific debugging to stderr
+        self.debug_multilog = False
         # All recognized events are logged
         self.debug_events = False
         # All transported events are logged
@@ -2472,6 +2607,57 @@ class Config(object):
                     values[1])
         self.datahub = value
 
+    def validate_pathname(self, args=None, cmd_line=True, path=None):
+        """
+        For the '--multilog' option where a wildcard can be used in the directory name.
+        Validates the string that is passed to the agent from command line, config file or server.
+        If error from command line, then error message written to commond line and agent quits.
+        If error from config file (or server) then error message written to log and False is returned.
+        :param args: the pathname given to the agent
+        :return:    True if okay, the agent will die otherwise
+        """        
+        if cmd_line and path is None:
+            if args is not None:
+                pname_slice = args[1:]
+                # validate that a pathname is detected in parameters to agent
+                if len(pname_slice) == 0:
+                    die("\nError: No pathname detected - Specify the path to the file to be followed\n" + MULTILOG_USAGE, EXIT_OK)
+                # validate that agent is not receiving a list of pathnames (possibly shell is expanding wildcard)
+                if len(pname_slice) > 1:
+                    die("\nError: Too many arguments being passed to agent\n" + MULTILOG_USAGE, EXIT_OK)
+                pname = str(pname_slice[0])
+        elif not cmd_line and path is None:
+            #for anything not coming in on command line no output is written to command line
+            log.error("Error: Pathname argument is empty")
+            return False
+        elif not cmd_line and path is not None:
+            pname=path
+        filename = os.path.basename(pname)
+        # verify there is a filename
+        if not filename:
+            if not cmd_line:
+                log.error("Error: No filename detected in the pathname")
+                return False
+            else:
+                die("\nError: No filename detected - Specify the filename to be followed\n" + MULTILOG_USAGE, EXIT_OK)
+        # check if a wildcard detected in pathname
+        if '*' in pname:
+            # verify that only one wildcard is in pathname
+            if pname.count('*') > 1:
+                if not cmd_line:
+                    log.error("Error: More then one wildcard * detected in pathname")
+                    return False
+                else:                
+                    die("\nError: Only one wildcard * allowed\n" + MULTILOG_USAGE, EXIT_OK)
+            # verify that no wildcard is in filename
+            if '*' in filename:
+                if not cmd_line:
+                    log.error("Error: Wildcard detected in filename of path argument")
+                    return False
+                else:
+                    die("\nError: No wildcard * allowed in filename\n" + MULTILOG_USAGE, EXIT_OK)
+        return True
+
     def process_params(self, params):
         """
         Parses command line parameters and updates config parameters accordingly
@@ -2479,11 +2665,11 @@ class Config(object):
         param_list = """user-key= account-key= agent-key= host-key= no-timestamps debug-events
                     debug-transport-events debug-metrics
                     debug-filters debug-formatters debug-loglist local debug-stats debug-nostats
-                    debug-stats-only debug-cmds debug-system help version yes force uuid list
+                    debug-stats-only debug-cmd-line debug-system help version yes force uuid list
                     std std-all name= hostname= type= pid-file= debug no-defaults
                     suppress-ssl use-ca-provided force-api-host= force-domain=
                     system-stat-token= datahub= legacy_v1_metrics
-                    pull-server-side-config= config= config.d="""
+                    pull-server-side-config= config= config.d= multilog debug-multilog"""
         try:
             optlist, args = getopt.gnu_getopt(params, '', param_list.split())
         except getopt.GetoptError, err:
@@ -2534,6 +2720,10 @@ class Config(object):
                 self.no_timestamps = True
             elif name == "--debug":
                 self.debug = True
+            elif name == "--debug-cmd-line":
+                self.debug_cmd_line = True
+            elif name == "--debug-multilog":
+                self.debug_multilog = True
             elif name == "--debug-events":
                 self.debug_events = True
             elif name == "--debug-transport-events":
@@ -2577,6 +2767,9 @@ class Config(object):
                 self.pull_server_side_config = value == "True"
             elif name == "--datahub":
                 self.set_datahub_settings(value)
+            elif name == "--multilog":
+                # multilog is only True if pathname is good
+                self.multilog = self.validate_pathname(args,True,None)
 
         if self.datahub_ip and not self.datahub_port:
             if self.suppress_ssl:
@@ -3040,6 +3233,7 @@ def start_followers(default_transport):
     logs = []
     followers = []
     transports = []
+    follow_multilogs = []
 
     if config.pull_server_side_config:
         # Use LE server as the source for list of followed logs
@@ -3113,10 +3307,17 @@ def start_followers(default_transport):
             log_token = ''
             if l['type'] == 'token':
                 log_token = l['token']
+            multilog_filename = False
+            if log_filename.startswith(PREFIX_MULTILOG_FILENAME):                                    
+                log_filename = log_filename.replace(PREFIX_MULTILOG_FILENAME,'',1).lstrip()
+                if not config.validate_pathname(None,False,log_filename):
+                    continue
+                multilog_filename = True
 
             # Do not start a follower for a log with absent filepath.
             if not check_file_name(log_filename):
                 continue
+            #log.info("After check_file_name:log_filename %s",log_filename )
 
             entry_filter = get_filters(available_filters, filter_filenames,
                                        log_name, log_key, log_filename,
@@ -3177,10 +3378,14 @@ def start_followers(default_transport):
             if not entry_formatter:
                 entry_formatter = formats.get_formatter('syslog', config.hostname, log_name, log_token)
 
-            # Instantiate the follower
-            follower = Follower(log_filename, entry_filter, entry_formatter, entry_identifier, transport)
-            followers.append(follower)
-    return (followers, transports)
+            # Instantiate the follow_multilog for 'multilog' filename, otherwise the individual follower
+            if multilog_filename:                
+                follow_multilog = FollowMultilog(log_filename, entry_filter, entry_formatter, entry_identifier, transport)
+                follow_multilogs.append(follow_multilog)
+            else:
+                follower = Follower(log_filename, entry_filter, entry_formatter, entry_identifier, transport)
+                followers.append(follower)
+    return (followers, transports, follow_multilogs)
 
 
 def is_followed(filename):
@@ -3192,6 +3397,41 @@ def is_followed(filename):
         if ilog['follow'] == 'true' and filename == ilog['filename']:
             return True
     return False
+
+def get_log_names_for_files(filenames):
+    """
+    Checks if each file in a list of files is followed. Will only make the one call on the server!
+    If it is, gets the 'name' of the log for this file. If not, then a 'None' is used.
+    :param filenames:   the list of filenames of interest
+    :return:    returns a {} of filenames with either the
+                associated log name or 'None' for each file
+    """
+    if len(filenames) == 0:
+        die('\nWarning: List of filenames is empty\n')
+    host = request('hosts/%s/' % config.agent_key, True, True)
+    logs = host['list']
+    result = {}
+    for filename in filenames:
+        result[filename] = NOT_SET
+        for ilog in logs:
+            if ilog['follow'] == 'true' and filename == ilog['filename']:
+                result[filename] = str(ilog['name'])
+    return result
+
+
+def get_loglist_with_paths():
+    """
+        Returns a list of all destination logs on the logentries infrastructure for
+        a host with the path that the log is using for following a file or mutliple files
+    :return :
+    """
+    host = request('hosts/%s/' % config.agent_key, True, True)
+    logs = host['list']
+    result = {}
+    for ilog in logs:
+        if ilog['follow'] == 'true':
+            result[str(ilog['name'])] = str(ilog['filename'])
+    return result
 
 
 def create_configured_logs(configured_logs):
@@ -3255,10 +3495,11 @@ def cmd_monitor(args):
 
     followers = []
     transports = []
+    follow_multilogs = []
     try:
         # Load logs to follow and start following them
         if not config.debug_stats_only:
-            (followers, transports) = start_followers(default_transport)
+            (followers, transports, follow_multilogs) = start_followers(default_transport)
 
         # Park this thread
         while True:
@@ -3275,6 +3516,9 @@ def cmd_monitor(args):
     # Close followers
     for follower in followers:
         follower.close()
+    # Close each follow_multilog and the followers it holds
+    for follow_multilog in follow_multilogs:
+        follow_multilog.close()
     # Close transports
     for transport in transports:
         transport.close()
@@ -3324,6 +3568,76 @@ def cmd_follow(args):
 
     request_follow(filename, name, type_opt)
 
+
+def cmd_follow_multilog(args):
+    """
+    Follow the log(s) as defined in string passed to agent with
+    the '--multilog' parameter included - modification of cmd_follow
+    """
+    if len(args) == 0:
+        die("Error: Specify the file name of the log to follow.")
+    if len(args) > 1:
+        die("Error: Too many arguments.\n"
+            "A common mistake is to use wildcards in path that is being "
+            "expanded by shell. Enclose the path in single quotes to avoid "
+            "expansion.")
+    config.load()
+    config.agent_key_required()
+    arg = args[0]
+    path = os.path.abspath(arg)
+    # when testing ignore user input
+    if config.debug_multilog:
+        follow = True
+    else:
+        follow = user_prompt(path)
+    if follow:
+        name = config.name
+        if name == NOT_SET:
+            name = os.path.basename(path)
+        type_opt = config.type_opt
+        if type_opt == NOT_SET:
+            type_opt = ""
+        filename = PREFIX_MULTILOG_FILENAME + path
+        request_follow(filename, name, type_opt)
+
+def user_prompt(path):
+    """
+    Displays 2 lists - files already followed with log names, and those not.
+    Prompts user if they wish to follow files or not
+    """
+    file_candidates = glob.glob(path)
+    loglist_with_paths = get_loglist_with_paths()
+    identical_path = False
+    print "\nExisting destination Logs for this host and the associated Paths are:"
+    print('\t{0:50}{1}'.format('LOGNAME', 'PATH'))
+    for logname, filepath in loglist_with_paths.items():
+        # test if an identical path is already in use!
+        if path == filepath.replace(PREFIX_MULTILOG_FILENAME,'',1).lstrip():
+            identical_path = True
+            print('\t{0:40}{1:10}{2}'.format(logname,"IDENTICAL", filepath))
+        else:
+            print('\t{0:50}{1}'.format(logname, filepath))
+    if identical_path:
+        print "NOTE: there are destination logs in above list with identical paths."
+    print "\nRequested path is: %s" % path
+    if len(file_candidates) == 0:
+        print "\nNo Files were found for this path at this time.\n"
+    else:
+        print "\nFiles found for this path:"
+        file_count = 0
+        for filename in file_candidates:
+            if file_count < MAX_FILES_FOLLOWED:
+                print ('\t{0}'.format(filename))
+                file_count = file_count+1        
+    while True:
+        print "\nUse new path to follow files [y] or quit [n]?"        
+        user_resp = raw_input().lower()        
+        if user_resp == 'n':
+            sys.exit(EXIT_OK)
+        elif user_resp == 'y':
+            return True
+        else:
+            print "Please try again"
 
 def cmd_followed(args):
     """
@@ -3566,6 +3880,9 @@ def main_root():
     if config.debug_loglist:
         die(collect_log_names(system_detect(True)))
 
+    if config.debug_cmd_line:
+        print >> sys.stderr, 'Debug command line args: %s' % args
+
     argv0 = sys.argv[0]
     if argv0 and argv0 != '':
         pname = os.path.basename(argv0).split('-')
@@ -3593,7 +3910,10 @@ def main_root():
     }
     for cmd, func in commands.items():
         if cmd == args[0]:
-            return func(args[1:])
+            if config.multilog and cmd == 'follow':
+                return cmd_follow_multilog(args[1:])
+            else:
+                return func(args[1:])
     die('Error: Unknown command "%s".' % args[0])
 
 

--- a/test/mocks/api_mock.py
+++ b/test/mocks/api_mock.py
@@ -18,200 +18,265 @@ CWD = os.getcwd()
 
 HOST0_KEY = "41ae887a-284a-4d78-91fe-56485b076148"
 HOST1_KEY = "86707421-6a05-4c70-9034-e5e30b6a1a44"
+HOST2_KEY = "9df0ea6f-36fa-820f-a6bc-c97da8939a06"
 LOG0_KEY = "400da462-36fa-48f4-bb4e-87f96ad34e8a"
 LOG1_KEY = "ee0489cc-41ce-41cf-9bb6-4cdf5e5acf32"
+LOG2_KEY = "484d6e95-a4e1-42fe-820f-5a4c0824428c"
+LOG3_KEY = "fa32313c-3907-4214-ac41-3ff9c6549a22"
+LOG_DYNAMIC_KEY = "32fa313c-4c70-4214-9bb6-3ff9c6549a22"
 
 LOG0 = {
-	"object":"log",
-	"key":LOG0_KEY,
-	"name":"Log name 0",
-	"filename":CWD +"/example.log",
-	"created":1414611930412,
-	"type":"agent",
-	"follow":"true",
-	"retention":-1,
+    "object":"log",
+    "key":LOG0_KEY,
+    "name":"Log name 0",
+    "filename":CWD +"/example.log",
+    "created":1414611930412,
+    "type":"agent",
+    "follow":"true",
+    "retention":-1,
 }
 
-
 LOG1 = {
-	"object":"log",
-	"key":LOG1_KEY,
-	"name":"Log name 1",
-	"filename":CWD +"/example2.log",
-	"created":1418775058756,
-	"type":"token",
-	"logtype":"444e607f-14bd-405e-a2ce-c4892b5a3b15",
-	"follow":"false",
-	"retention":-1,
-	"token": "120fb800-94c0-446a-be28-cfbbc36b52eb"
+    "object":"log",
+    "key":LOG1_KEY,
+    "name":"Log name 1",
+    "filename":CWD +"/example2.log",
+    "created":1418775058756,
+    "type":"token",
+    "logtype":"444e607f-14bd-405e-a2ce-c4892b5a3b15",
+    "follow":"false",
+    "retention":-1,
+    "token": "120fb800-94c0-446a-be28-cfbbc36b52eb"
+}
+
+# LOG-7549 Test case
+LOG2 = {
+    "object":"log",
+    "key":LOG2_KEY,
+    "name":"Apache",
+    "filename":"Multilog:" + CWD +"/apache*/current",
+    "created":1418711930412,
+    "type":"agent",
+    "follow":"true",
+    "retention":-1,
+}
+
+# LOG-7549 Test case
+LOG3 = {
+    "object":"log",
+    "key":LOG3_KEY,
+    "name":"current",
+    "filename":"Multilog:" + CWD +"/apache-01/current",
+    "created":1418711930412,
+    "type":"agent",
+    "follow":"true",
+    "retention":-1,
 }
 
 HOST0 = {
-	"object":"host",
-	"key":HOST0_KEY,
-	"hostname":"0.example.com",
-	"c":1315863111149,
-	"distname":"Debian",
-	"name":"Name1",
-	"distver":"wheezy",
+    "object":"host",
+    "key":HOST0_KEY,
+    "hostname":"0.example.com",
+    "c":1315863111149,
+    "distname":"Debian",
+    "name":"Name1",
+    "distver":"wheezy",
 }
 
 HOST1 = {
-	"object":"host",
-	"key":HOST1_KEY,
-	"hostname":"1.example.com",
-	"c":1385398282448,
-	"distname":"Debian",
-	"name":"Name2",
-	"distver":"jessie",
+    "object":"host",
+    "key":HOST1_KEY,
+    "hostname":"1.example.com",
+    "c":1385398282448,
+    "distname":"Debian",
+    "name":"Name2",
+    "distver":"jessie",
+}
+
+HOST2 = {
+    "object":"host",
+    "key":HOST2_KEY,
+    "hostname":"2.example.com",
+    "c":1385398282559,
+    "distname":"Debian",
+    "name":"Multilog",
+    "distver":"jessie",
 }
 
 
 class ApiHandler( cyclone.web.RequestHandler):
-	def get( self):
-		self.write( "API mock server is running")
+    def get( self):
+        self.write( "API mock server is running")
 
-	def post( self):
-		request = self.get_argument( 'request')
-		if request == 'register':
-			distver = self.get_argument( 'distver')
-			name = self.get_argument( 'name')
-			distname = self.get_argument( 'distname')
-			hostname = self.get_argument( 'hostname')
-			self.write( json.dumps( {
-				'response': 'ok',
-				'host_key': HOST0_KEY,
-				'agent_key': HOST0_KEY,
-				'host': {
-					'object': 'host',
-					'key': HOST0_KEY,
-					'hostname': hostname, # XXX
-					'c': 1315863111149,
-					'distname': distname,
-					'name': name,
-					'distver': distver,
-				},
-				'worker': 'a0',
-			}))
-		elif request == 'new_log':
-			host_key = self.get_argument( 'host_key')
-			if host_key == HOST0_KEY:
-				self.write( json.dumps( {
-					'response': 'ok',
-					'log_key': LOG0_KEY,
-					'log': LOG0,
-					'worker': 'a0',
-				}))
-			elif host_key == HOST1_KEY:
-				self.write( json.dumps( {
-					'response': 'ok',
-					'log_key': LOG1_KEY,
-					'log': LOG1,
-					'worker': 'a0',
-				}))
-		elif request == 'get_user':
-			load_logs = self.get_argument('load_logs')
-			resp = {
-				'response': 'ok',
-				'hosts': [ HOST0, HOST1 ]
-			}
-			if load_logs == 'true':
-				resp['hosts'][0]['logs'] = [ LOG0 ]
-				resp['hosts'][1]['logs'] = [ LOG1 ]
-			self.write( json.dumps( resp))
-		else:
-			raise cyclone.web.HTTPError( 400)
+    def post( self):
+        request = self.get_argument( 'request')
+        if request == 'register':
+            distver = self.get_argument( 'distver')
+            name = self.get_argument( 'name')
+            distname = self.get_argument( 'distname')
+            hostname = self.get_argument( 'hostname')
+            self.write( json.dumps( {
+                'response': 'ok',
+                'host_key': HOST0_KEY,
+                'agent_key': HOST0_KEY,
+                'host': {
+                    'object': 'host',
+                    'key': HOST0_KEY,
+                    'hostname': hostname, # XXX
+                    'c': 1315863111149,
+                    'distname': distname,
+                    'name': name,
+                    'distver': distver,
+                },
+                'worker': 'a0',
+            }))
+        elif request == 'new_log':
+            host_key = self.get_argument( 'host_key')
+            if host_key == HOST0_KEY:
+                self.write( json.dumps( {
+                    'response': 'ok',
+                    'log_key': LOG0_KEY,
+                    'log': LOG0,
+                    'worker': 'a0',
+                }))
+            elif host_key == HOST1_KEY:
+                self.write( json.dumps( {
+                    'response': 'ok',
+                    'log_key': LOG1_KEY,
+                    'log': LOG1,
+                    'worker': 'a0',
+                }))
+            elif host_key == HOST2_KEY:
+                logname = self.get_argument('name')
+                filename = self.get_argument('filename')
+                follow = self.get_argument('follow')
+                self.write( json.dumps( {
+                    'response': 'ok',
+                    'log_key': LOG_DYNAMIC_KEY,
+                    'log': {
+                        "object":"log",
+                        "key":LOG_DYNAMIC_KEY,
+                        "name":logname,
+                        "filename":filename,
+                        "created":1418711930412,
+                        "type":"agent",
+                        "follow":follow,
+                        "retention":-1,
+                    },
+                    'worker': 'a0',
+                }))
+        elif request == 'get_user':
+            load_logs = self.get_argument('load_logs')
+            resp = {
+                'response': 'ok',
+                'hosts': [ HOST0, HOST1 ]
+            }
+            if load_logs == 'true':
+                resp['hosts'][0]['logs'] = [ LOG0 ]
+                resp['hosts'][1]['logs'] = [ LOG1 ]
+            self.write( json.dumps( resp))
+        else:
+            raise cyclone.web.HTTPError( 400)
 
 class AccountHandler( cyclone.web.RequestHandler):
-	def get( self, account_id):
-		self.write( json.dumps({
-			"response":"ok",
-			"object":"rootlist",
-			"list":[
-				{
-					"name":"logs",
-					"key":""
-				},{
-					"name":"hosts",
-					"key":""
-				},{
-					"name":"hostnames",
-					"key":""
-				},{
-					"name":"apps",
-					"key":""
-				},{
-					"name":"clusters",
-					"key":""
-				},{
-					"name":"logtypes",
-					"key":""
-				}],
-			}))
+    def get( self, account_id):
+        self.write( json.dumps({
+            "response":"ok",
+            "object":"rootlist",
+            "list":[
+                {
+                    "name":"logs",
+                    "key":""
+                },{
+                    "name":"hosts",
+                    "key":""
+                },{
+                    "name":"hostnames",
+                    "key":""
+                },{
+                    "name":"apps",
+                    "key":""
+                },{
+                    "name":"clusters",
+                    "key":""
+                },{
+                    "name":"logtypes",
+                    "key":""
+                }],
+            }))
 
 class HostsHandler( cyclone.web.RequestHandler):
-	def get( self, account_id):
-		self.write( json.dumps({
-			"response":"ok",
-			"object":"hostlist",
-			"list":[ HOST0, HOST1 ],
-		}))
+    def get( self, account_id):
+        self.write( json.dumps({
+            "response":"ok",
+            "object":"hostlist",
+            "list":[ HOST0, HOST1 ],
+        }))
 
 class HostHandler( cyclone.web.RequestHandler):
-	def get( self, account_id, host_id):
-		if host_id in [HOST0_KEY, HOST0['name']]:
-			self.write( response_ok( HOST0))
-		elif host_id in [HOST1_KEY, HOST1['name']]:
-			self.write( response_ok( HOST1))
-		else:
-			raise cyclone.web.HTTPError( 403)
+    def get( self, account_id, host_id):
+        if host_id in [HOST0_KEY, HOST0['name']]:
+            self.write( response_ok( HOST0))
+        elif host_id in [HOST1_KEY, HOST1['name']]:
+            self.write( response_ok( HOST1))
+        else:
+            raise cyclone.web.HTTPError( 403)
 
 class HostLogsHandler( cyclone.web.RequestHandler):
-	def get( self, account_id, host_id):
-		if host_id in [HOST0_KEY, HOST0['name']]:
-			self.write( response_ok( {
-				"object":"loglist",
-				"list":[ LOG0, LOG1],
-			}))
-		elif host_id in [HOST1_KEY, HOST1['name']]:
-			self.write( response_ok( {
-				"object":"loglist",
-				"list":[],
-			}))
-		else:
-			raise cyclone.web.HTTPError( 403)
+    def get( self, account_id, host_id):
+        if host_id in [HOST0_KEY, HOST0['name']]:
+            self.write( response_ok( {
+                "object":"loglist",
+                "list":[ LOG0, LOG1],
+            }))
+        elif host_id in [HOST1_KEY, HOST1['name']]:
+            self.write( response_ok( {
+                "object":"loglist",
+                "list":[],
+            }))
+        elif host_id in [HOST2_KEY, HOST2['name']]:
+            self.write( response_ok( {
+                "object":"loglist",
+                "list":[LOG2],
+            }))
+        else:
+            raise cyclone.web.HTTPError( 403)
 
 class LogHandler( cyclone.web.RequestHandler):
-	def get( self, account_id, host_id, log_id):
-		if log_id in [LOG0_KEY, LOG0['name']]:
-			self.write( response_ok( LOG0))
-		elif log_id in [LOG1_KEY, LOG1['name']]:
-			self.write( response_ok( LOG1))
+    def get( self, account_id, host_id, log_id):
+        if log_id in [LOG0_KEY, LOG0['name']]:
+            self.write( response_ok( LOG0))
+        elif log_id in [LOG1_KEY, LOG1['name']]:
+            self.write( response_ok( LOG1))
 
 class IngestionHandler( cyclone.web.RequestHandler):
-	@asynchronous
-	def put( self, account_id, host_id, log_id):
-		if log_id in [LOG0_KEY, LOG0['name']]:
-			pass
-		elif log_id in [LOG1_KEY, LOG1['name']]:
-			pass
+    @asynchronous
+    def put( self, account_id, host_id, log_id):
+        if log_id in [LOG0_KEY, LOG0['name']]:
+            pass
+        elif log_id in [LOG1_KEY, LOG1['name']]:
+            pass
+        elif log_id in [LOG2_KEY, LOG2['name']]:
+            pass
+        elif log_id in [LOG3_KEY, LOG3['name']]:
+            pass
 
 def response_ok( x):
-	a = { 'response': 'ok'}
-	a.update( x)
-	return json.dumps( a)
+    a = { 'response': 'ok'}
+    a.update( x)
+    return json.dumps( a)
 
 if __name__ == "__main__":
-	application = cyclone.web.Application([
-		(r"/", ApiHandler),
-		(r"/([a-z0-9-]+)/", AccountHandler),
-		(r"/([a-z0-9-]+)/hosts", HostsHandler),
-		(r"/([a-z0-9-]+)/hosts/([a-zA-Z0-9%-]+)", HostHandler),
-		(r"/([a-z0-9-]+)/hosts/([a-zA-Z0-9%-]+)/", HostLogsHandler),
-		(r"/([a-z0-9-]+)/hosts/([a-zA-Z0-9%-]+)/([a-zA-Z0-9%-]+)", LogHandler),
-		(r"/([a-z0-9-]+)/hosts/([a-zA-Z0-9%-]+)/([a-zA-Z0-9%-]+)/.*", IngestionHandler),
-	])
-	log.startLogging( sys.stdout)
-	reactor.listenTCP( 8081, application)
-	reactor.run()
+    application = cyclone.web.Application([
+        (r"/", ApiHandler),
+        (r"/([a-z0-9-]+)/", AccountHandler),
+        (r"/([a-z0-9-]+)/hosts", HostsHandler),
+        (r"/([a-z0-9-]+)/hosts/([a-zA-Z0-9%-]+)", HostHandler),
+        (r"/([a-z0-9-]+)/hosts/([a-zA-Z0-9%-]+)/", HostLogsHandler),
+        (r"/([a-z0-9-]+)/hosts/([a-zA-Z0-9%-]+)/([a-zA-Z0-9%-]+)", LogHandler),
+        (r"/([a-z0-9-]+)/hosts/([a-zA-Z0-9%-]+)/([a-zA-Z0-9%-]+)/.*", IngestionHandler),
+    ])
+    log.startLogging( sys.stdout)
+    reactor.listenTCP( 8081, application)
+    reactor.run()
 

--- a/test/tests.d/help.sh
+++ b/test/tests.d/help.sh
@@ -44,5 +44,6 @@ $LE
 #e                           the format is address:port with port being optional
 #e   --system-stat-token=    set the token for system stats log (beta)
 #e   --pull-server-side-config=False do not use server-side config for following files
+#e   --multilog              option used with directory wildcard * (restricted behaviour)
 #e
 

--- a/test/tests.d/help.sh
+++ b/test/tests.d/help.sh
@@ -23,6 +23,7 @@ $LE
 #e   follow <filename>  Follow the given log
 #e     --name=  name of the log
 #e     --type=  type of the log
+#e     --multilog option used with directory wildcard * (restricted behaviour)
 #e   followed <filename>  Check if the file is followed
 #e   clean     Removes configuration file
 #e   ls        List internal filesystem and settings: <path>
@@ -43,7 +44,7 @@ $LE
 #e   --datahub               send logs to the specified data hub address
 #e                           the format is address:port with port being optional
 #e   --system-stat-token=    set the token for system stats log (beta)
-#e   --pull-server-side-config=False do not use server-side config for following files
-#e   --multilog              option used with directory wildcard * (restricted behaviour)
-#e
+#e   --pull-server-side-config=False do not use server-side config for following files 
+#e 
+ 
 

--- a/test/tests.d/multilog_configuration.sh
+++ b/test/tests.d/multilog_configuration.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+. vars
+
+#############                                                      ##############
+#       "multilog configuration"                                                #
+#       Test Scope: Use of client configuration file with a multilog            # 
+#       wildcard pathname for monitoring of files.                              #
+#                                                                               #
+#############                                                      ##############
+
+Scenario 'Using client side configuration with multilog pathname'
+
+Testcase 'init and set client configuration with wildcard in multilog pathname'
+
+$LE init --account-key=$ACCOUNT_KEY --host-key=$HOST_MULTILOG_KEY
+#e Initialized
+
+echo 'pull-server-side-config = False' >>"$CONFIG"
+echo '[Apache]' >>"$CONFIG"
+echo 'token = 0b52788c-7981-4138-ac40-6720ae2d5f0c' >>"$CONFIG"
+echo "path = Multilog:$TMP/apache*/current" >>"$CONFIG"
+cat "$CONFIG"
+#o [Main]
+#o user-key = f720fe54-879a-11e4-81ac-277d856f873e
+#o agent-key = 9df0ea6f-36fa-820f-a6bc-c97da8939a06
+#o v1_metrics = False
+#o metrics-mem = system
+#o metrics-token = 
+#o metrics-disk = sum
+#o metrics-swap = system
+#o metrics-space = /
+#o metrics-vcpu = 
+#o metrics-net = sum
+#o metrics-interval = 5s
+#o metrics-cpu = system
+#o
+#o pull-server-side-config = False
+#o [Apache]
+#o token = 0b52788c-7981-4138-ac40-6720ae2d5f0c
+#o path = Multilog:$TMP/apache*/current
+
+Testcase 'Monitoring file in multiple directories'
+
+mkdir apache-01
+touch apache-01/current
+mkdir apache-02
+touch apache-02/current
+mkdir apache-03
+touch apache-03/current
+
+$LE --debug-events monitor &
+#e Configuration files loaded: sandbox_config
+#e V1 metrics disabled
+#e Following $TMP/apache*/current
+#e Opening connection 127.0.0.1:10000 
+LE_PID=$!
+
+sleep 1
+echo 'First message' >> apache-01/current
+sleep 1
+#e First message
+echo 'Second message' >> apache-02/current
+sleep 1
+#e Second message
+echo 'Third message' >> apache-03/current
+#e Third message
+sleep 1
+
+# tidy up test directory and daemon
+rm -rf apache*
+kill $LE_PID
+

--- a/test/tests.d/multilog_dynamic.sh
+++ b/test/tests.d/multilog_dynamic.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+. vars
+
+#############                                                      ##############
+#       "multilog dynamic"                                                      #
+#       Test Scope: 'dynamic' behaviour for '--multilog' wildcard.              #  
+#       The Agent is initialised and then the command line used to set the      #
+#       agent to follow a filepath with a wildcard. The 'dynamic' behaviour     #
+#       of the agent for '--multilog' option is then tested.                    #
+#       Refer to the agent README for details on this 'dynamic' behaviour.      #    
+#                                                                               #
+#############                                                      ##############
+
+Scenario 'Using client side configuration to test dynamic behaviour'
+
+Testcase 'init and set client configuration with wildcard for dynamic behaviour'
+
+$LE init --account-key=$ACCOUNT_KEY --host-key=$HOST_MULTILOG_KEY
+#e Initialized
+
+echo 'pull-server-side-config = False' >>"$CONFIG"
+echo '[Apache]' >>"$CONFIG"
+echo 'token = 0b52788c-7981-4138-ac40-6720ae2d5f0c' >>"$CONFIG"
+echo "path = Multilog:$TMP/apache*/current" >>"$CONFIG"
+cat "$CONFIG"
+#o [Main]
+#o user-key = f720fe54-879a-11e4-81ac-277d856f873e
+#o agent-key = 9df0ea6f-36fa-820f-a6bc-c97da8939a06
+#o v1_metrics = False
+#o metrics-mem = system
+#o metrics-token = 
+#o metrics-disk = sum
+#o metrics-swap = system
+#o metrics-space = /
+#o metrics-vcpu = 
+#o metrics-net = sum
+#o metrics-interval = 5s
+#o metrics-cpu = system
+#o
+#o pull-server-side-config = False
+#o [Apache]
+#o token = 0b52788c-7981-4138-ac40-6720ae2d5f0c
+#o path = Multilog:$TMP/apache*/current
+
+Testcase 'Follow file across existing directories; new ones created; stop following when directories deleted'
+
+mkdir apache-01
+touch apache-01/current
+mkdir apache-02
+touch apache-02/current
+mkdir apache-03
+touch apache-03/current
+
+$LE --debug-events --debug-multilog monitor &
+#e Configuration files loaded: sandbox_config
+#e V1 metrics disabled
+#e Following $TMP/apache*/current
+#e Opening connection 127.0.0.1:10000 
+#e Number of followers increased to: 1 
+#e Number of followers increased to: 2 
+#e Number of followers increased to: 3 
+LE_PID=$!
+sleep 1
+echo 'First message' >> apache-01/current
+sleep 1
+#e First message
+echo 'Second message' >> apache-02/current
+sleep 1
+#e Second message
+echo 'Third message' >> apache-03/current
+#e Third message
+sleep 1
+mkdir apache-04
+touch apache-04/current
+#e Number of followers increased to: 4 
+sleep 1
+echo 'Fourth message' >> apache-01/current
+sleep 1
+#e Fourth message
+rm -rf apache-01
+sleep 1
+#e Number of followers decreased to: 3 
+
+# tidy up test directory and daemon
+rm -rf apache*
+kill $LE_PID
+wait $LE_PID 2>/dev/null || true
+
+
+Scenario 'Using server side configuration to test dynamic behaviour'
+
+Testcase 'Init'
+$LE init --account-key=$ACCOUNT_KEY --host-key=$HOST_MULTILOG_KEY
+#e Initialized
+
+Testcase 'Follow file across directories as new ones created; stop following when directories deleted'
+
+$LE --debug-events --debug-multilog monitor &
+#e Configuration files loaded: sandbox_config
+#e V1 metrics disabled
+#e Connecting to 127.0.0.1:8081
+#e Domain request: GET /f720fe54-879a-11e4-81ac-277d856f873e/hosts/9df0ea6f-36fa-820f-a6bc-c97da8939a06/ None {}
+#e List response: {"object": "loglist", "list": [{"name": "Apache", "key": "484d6e95-a4e1-42fe-820f-5a4c0824428c", "created": 1418711930412, "retention": -1, "follow": "true", "object": "log", "type": "agent", "filename": "Multilog:$TMP/apache*/current"}], "response": "ok"}
+#e Following $TMP/apache*/current
+#e Opening connection 127.0.0.1:8081 PUT /f720fe54-879a-11e4-81ac-277d856f873e/hosts/9df0ea6f-36fa-820f-a6bc-c97da8939a06/484d6e95-a4e1-42fe-820f-5a4c0824428c/?realtime=1 HTTP/1.0
+
+LE_PID=$!
+mkdir apache-01
+touch apache-01/current
+mkdir apache-02
+touch apache-02/current
+mkdir apache-03
+touch apache-03/current
+
+#e Number of followers increased to: 1 
+#e Number of followers increased to: 2 
+#e Number of followers increased to: 3 
+sleep 1
+echo 'First message' >> apache-01/current
+sleep 1
+#e First message
+echo 'Second message' >> apache-02/current
+sleep 1
+#e Second message
+echo 'Third message' >> apache-03/current
+#e Third message
+sleep 1
+rm -rf apache-01
+sleep 1
+#e Number of followers decreased to: 2 
+echo 'Fourth message' >> apache-02/current
+sleep 1
+#e Fourth message
+echo 'Fifth message' >> apache-03/current
+sleep 1
+#e Fifth message
+
+# tidy up test directory and daemon
+rm -rf apache*
+kill $LE_PID

--- a/test/tests.d/multilog_pathname_verification.sh
+++ b/test/tests.d/multilog_pathname_verification.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+. vars
+
+#############                                                      ##############
+#       "multilog pathname verification"                                        #
+#       Test Scope: verification of pathname passed to agent,               #
+#       with the --multilog parameter                                           #
+#                                                                               #
+#############                                                      ##############
+
+# Reference: LOG-7549
+Scenario 'Verification of pathname rules with use of the --multilog parameter'
+
+Testcase 'Init'
+
+$LE init --account-key=$ACCOUNT_KEY --host-key=$HOST_MULTILOG_KEY
+#e Initialized
+
+Testcase 'Error message displayed when follow command used with more then one wildcard in pathname'
+
+$LE follow '$TMP/apache-*/*/current' --multilog
+#e
+#eError: Only one wildcard * allowed
+#e
+#eUsage:
+#e   Agent is expecting a path name for a file, which should be between single quotes:
+#e         example: '/var/log/directoryname/file.log'
+#e   A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+#e   Wildcard can not be used for expansion of filename, but for directory name only.
+#e   Place path name with wildcard between single quotes:
+#e         example: "/var/log/directory*/file.log"
+#e
+
+Testcase 'Error message displayed when follow command used with wildcard for filename'
+
+$LE follow '$TMP/apache-01/*' --multilog
+#e
+#eError: No wildcard * allowed in filename
+#e
+#eUsage:
+#e   Agent is expecting a path name for a file, which should be between single quotes:
+#e         example: '/var/log/directoryname/file.log'
+#e   A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+#e   Wildcard can not be used for expansion of filename, but for directory name only.
+#e   Place path name with wildcard between single quotes:
+#e         example: "/var/log/directory*/file.log"
+#e
+
+Testcase 'Error message displayed when follow command used with wildcard in partial filename'
+
+$LE follow '$TMP/apache-01/curr*' --multilog
+#e
+#eError: No wildcard * allowed in filename
+#e
+#eUsage:
+#e   Agent is expecting a path name for a file, which should be between single quotes:
+#e         example: '/var/log/directoryname/file.log'
+#e   A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+#e   Wildcard can not be used for expansion of filename, but for directory name only.
+#e   Place path name with wildcard between single quotes:
+#e         example: "/var/log/directory*/file.log"
+#e
+
+Testcase 'Error message displayed when follow command used with wildcard in partial filename, without single quotes'
+
+$LE follow $TMP/apache-01/curr* --multilog
+#e
+#eError: No wildcard * allowed in filename
+#e
+#eUsage:
+#e   Agent is expecting a path name for a file, which should be between single quotes:
+#e         example: '/var/log/directoryname/file.log'
+#e   A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+#e   Wildcard can not be used for expansion of filename, but for directory name only.
+#e   Place path name with wildcard between single quotes:
+#e         example: "/var/log/directory*/file.log"
+#e
+
+Testcase 'Error message displayed when follow command used with wildcard expanded by shell'
+# Example of where shell expansion of wildcard occurs because sigle quotes were not used,
+# resulting in multiple pathnames being used as arguments to agent
+
+mkdir apache-01
+touch apache-01/current
+mkdir apache-02
+touch apache-02/current
+mkdir apache-03
+touch apache-03/current
+
+$LE follow $TMP/*/current --multilog
+#e
+#eError: Too many arguments being passed to agent
+#e
+#eUsage:
+#e   Agent is expecting a path name for a file, which should be between single quotes:
+#e         example: '/var/log/directoryname/file.log'
+#e   A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+#e   Wildcard can not be used for expansion of filename, but for directory name only.
+#e   Place path name with wildcard between single quotes:
+#e         example: "/var/log/directory*/file.log"
+#e
+
+# tidy up test directory's
+rm -rf apache*
+
+Testcase 'Error message displayed when follow command used with no pathname'
+
+$LE follow  --multilog
+#e
+#eError: No pathname detected - Specify the path to the file to be followed
+#e
+#eUsage:
+#e   Agent is expecting a path name for a file, which should be between single quotes:
+#e         example: '/var/log/directoryname/file.log'
+#e   A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+#e   Wildcard can not be used for expansion of filename, but for directory name only.
+#e   Place path name with wildcard between single quotes:
+#e         example: "/var/log/directory*/file.log"
+#e
+
+Testcase 'Error message displayed when follow command used with wildcard but no filename'
+
+$LE follow  '/*/' --multilog
+#e
+#eError: No filename detected - Specify the filename to be followed
+#e
+#eUsage:
+#e   Agent is expecting a path name for a file, which should be between single quotes:
+#e         example: '/var/log/directoryname/file.log'
+#e   A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+#e   Wildcard can not be used for expansion of filename, but for directory name only.
+#e   Place path name with wildcard between single quotes:
+#e         example: "/var/log/directory*/file.log"
+#e
+
+Testcase 'Error message displayed when follow command used with empty string'
+
+$LE follow  '' --multilog
+#e
+#eError: No filename detected - Specify the filename to be followed
+#e
+#eUsage:
+#e   Agent is expecting a path name for a file, which should be between single quotes:
+#e         example: '/var/log/directoryname/file.log'
+#e   A * wildcard for expansion of directory name can be used. Only the one * wildcard is allowed.
+#e   Wildcard can not be used for expansion of filename, but for directory name only.
+#e   Place path name with wildcard between single quotes:
+#e         example: "/var/log/directory*/file.log"
+#e
+

--- a/test/tests.d/multilog_workflow.sh
+++ b/test/tests.d/multilog_workflow.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+. vars
+
+#############                                                      ##############
+#       "multilog workflow"                                                     #
+#       Test Scope: behaviour of agent with the --multilog parameter            #            
+#       using server side configuration                                         #
+#                                                                               #
+#############                                                      ##############
+
+# Reference: LOG-7549
+Scenario 'Agent follows files using --multilog parameter'
+
+Testcase 'Init'
+
+$LE init --account-key=$ACCOUNT_KEY --host-key=$HOST_MULTILOG_KEY
+#e Initialized
+
+Testcase 'Use --multilog parameter with pathname with no wildcard'
+
+$LE follow --debug-multilog "$TMP/apache-01/current" --multilog
+#e Configuration files loaded: sandbox_config
+#e Connecting to 127.0.0.1:8081
+#e Domain request: POST / host_key=9df0ea6f-36fa-820f-a6bc-c97da8939a06&name=current&user_key=f720fe54-879a-11e4-81ac-277d856f873e&request=new_log&filename=Multilog%3A%2Ftmp%2F$SUBDIR%2Fapache-01%2Fcurrent&follow=true&type= {'Content-Type': 'application/x-www-form-urlencoded'}
+#e Domain response: "{"log": {"name": "current", "key": "32fa313c-4c70-4214-9bb6-3ff9c6549a22", "created": 1418711930412, "retention": -1, "follow": "true", "object": "log", "type": "agent", "filename": "Multilog:$TMP/apache-01/current"}, "worker": "a0", "response": "ok", "log_key": "32fa313c-4c70-4214-9bb6-3ff9c6549a22"}"
+#o Will follow Multilog:$TMP/apache-01/current as current
+#e Don't forget to restart the daemon
+#e   sudo service logentries restart
+
+Testcase 'Use --multilog parameter with wildcard in a directory name in pathname'
+
+$LE follow --debug-multilog "$TMP/apache*/current" --multilog
+#e Configuration files loaded: sandbox_config
+#e Connecting to 127.0.0.1:8081
+#e Domain request: POST / host_key=9df0ea6f-36fa-820f-a6bc-c97da8939a06&name=current&user_key=f720fe54-879a-11e4-81ac-277d856f873e&request=new_log&filename=Multilog%3A%2Ftmp%2F$SUBDIR%2Fapache%2A%2Fcurrent&follow=true&type= {'Content-Type': 'application/x-www-form-urlencoded'}
+#e Domain response: "{"log": {"name": "current", "key": "32fa313c-4c70-4214-9bb6-3ff9c6549a22", "created": 1418711930412, "retention": -1, "follow": "true", "object": "log", "type": "agent", "filename": "Multilog:$TMP/apache*/current"}, "worker": "a0", "response": "ok", "log_key": "32fa313c-4c70-4214-9bb6-3ff9c6549a22"}"
+#o Will follow Multilog:$TMP/apache*/current as current
+#e Don't forget to restart the daemon
+#e   sudo service logentries restart
+
+Testcase 'Use the --name= option to specify log name when setting up files to follow'
+
+$LE follow --debug-multilog "$TMP/apache-*/current" --multilog --name=ApacheWeb
+#e Configuration files loaded: sandbox_config
+#e Connecting to 127.0.0.1:8081
+#e Domain request: POST / host_key=9df0ea6f-36fa-820f-a6bc-c97da8939a06&name=ApacheWeb&user_key=f720fe54-879a-11e4-81ac-277d856f873e&request=new_log&filename=Multilog%3A%2Ftmp%2F$SUBDIR%2Fapache-%2A%2Fcurrent&follow=true&type= {'Content-Type': 'application/x-www-form-urlencoded'}
+#e Domain response: "{"log": {"name": "ApacheWeb", "key": "32fa313c-4c70-4214-9bb6-3ff9c6549a22", "created": 1418711930412, "retention": -1, "follow": "true", "object": "log", "type": "agent", "filename": "Multilog:$TMP/apache-*/current"}, "worker": "a0", "response": "ok", "log_key": "32fa313c-4c70-4214-9bb6-3ff9c6549a22"}"
+#o Will follow Multilog:$TMP/apache-*/current as ApacheWeb
+#e Don't forget to restart the daemon
+#e   sudo service logentries restart
+
+# Reference: LOG-7549
+Scenario 'Agent follows multiple files with the same filename across a number of directories, writing to the one log'
+
+Testcase 'Init'
+
+$LE init --account-key=$ACCOUNT_KEY --host-key=$HOST_MULTILOG_KEY
+#e Initialized
+
+Testcase 'Verify agent follows files of the same filename across multiple directories'
+
+mkdir apache-01
+touch apache-01/current
+mkdir apache-02
+touch apache-02/current
+mkdir apache-03
+touch apache-03/current
+
+$LE --debug-events monitor &
+#e Configuration files loaded: sandbox_config
+#e V1 metrics disabled
+#e Connecting to 127.0.0.1:8081
+#e Domain request: GET /f720fe54-879a-11e4-81ac-277d856f873e/hosts/9df0ea6f-36fa-820f-a6bc-c97da8939a06/ None {}
+#e List response: {"object": "loglist", "list": [{"name": "Apache", "key": "484d6e95-a4e1-42fe-820f-5a4c0824428c", "created": 1418711930412, "retention": -1, "follow": "true", "object": "log", "type": "agent", "filename": "Multilog:$TMP/apache*/current"}], "response": "ok"}
+#e Following $TMP/apache*/current
+#e Opening connection 127.0.0.1:8081 PUT /f720fe54-879a-11e4-81ac-277d856f873e/hosts/9df0ea6f-36fa-820f-a6bc-c97da8939a06/484d6e95-a4e1-42fe-820f-5a4c0824428c/?realtime=1 HTTP/1.0
+LE_PID=$!
+
+sleep 1
+echo 'First message' >> apache-01/current
+sleep 1
+#e First message
+echo 'Second message' >> apache-02/current
+sleep 1
+#e Second message
+echo 'Third message' >> apache-03/current
+#e Third message
+sleep 1
+
+# tidy up test directory and daemon
+rm -rf apache*
+kill $LE_PID

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -28,6 +28,7 @@ for A in ${TESTS[*]} ; do
 
 	# Create temporary directory for storing test's outputs
 	export TMP=$(mktemp -d)
+	export SUBDIR=${TMP:5}
 
 	EXPECTED_STDOUT=$TMP/expected_stdout
 	EXPECTED_STDERR=$TMP/expected_stderr
@@ -37,8 +38,8 @@ for A in ${TESTS[*]} ; do
 	export XDG_CACHE_HOME=$TMP
 
 	# Extract expected output and real output (by running the test scenario)
-	sed -n -e 's/^#o \?\(.*\)$/\1/p' -e 's/^\(Scenario .*\)$/\n\n\1\n\n/p' -e 's/^\(Testcase .*\)$/\n\1\n/p' -- "$A" | sed "s|\$TMP|$TMP|g" >"$EXPECTED_STDOUT"
-	sed -n -e 's/^#e \?\(.*\)$/\1/p' -e 's/^\(Scenario .*\)$/\n\n\1\n\n/p' -e 's/^\(Testcase .*\)$/\n\1\n/p' -- "$A" | sed "s|\$TMP|$TMP|g" >"$EXPECTED_STDERR"
+	sed -n -e 's/^#o \?\(.*\)$/\1/p' -e 's/^\(Scenario .*\)$/\n\n\1\n\n/p' -e 's/^\(Testcase .*\)$/\n\1\n/p' -- "$A" | sed "s|\$TMP|$TMP|g" | sed "s|\$SUBDIR|$SUBDIR|g" >"$EXPECTED_STDOUT"
+	sed -n -e 's/^#e \?\(.*\)$/\1/p' -e 's/^\(Scenario .*\)$/\n\n\1\n\n/p' -e 's/^\(Testcase .*\)$/\n\1\n/p' -- "$A" | sed "s|\$TMP|$TMP|g" | sed "s|\$SUBDIR|$SUBDIR|g" >"$EXPECTED_STDERR"
 
 	for key in "${!TEMPLATES[@]}" ; do
 		sed -i "s!%$key%!${TEMPLATES[$key]}!g" $EXPECTED_STDERR

--- a/test/vars
+++ b/test/vars
@@ -14,6 +14,7 @@ LE="$DIR/../src/le.py --local --debug --config $CONFIG --config.d $CONFIG_D"
 
 ACCOUNT_KEY=f720fe54-879a-11e4-81ac-277d856f873e
 HOST_KEY=41ae887a-284a-4d78-91fe-56485b076148
+HOST_MULTILOG_KEY=9df0ea6f-36fa-820f-a6bc-c97da8939a06
 
 LE_PID=''
 API_MOCK_PID=''


### PR DESCRIPTION
Changes in this PR for Linux Agent

_api_mock.py_ 
- with new host and logs
- get 'loglist' response updated for new hosts/logs
- put IngestionHandler updated for new logs
- POST request handling is now dynamic for core multilog test cases   

_le.py_
- LE updated to handle new paramter --multilog
- Function added to verify pathname (from command line; config file or server side) against rules per story
- Function added for display of user prompt as per story requirment
- Function added for handling request to follow for 'multilog' option
- Text Added for Usage of Multilog
- Added new debug command --debug-multilog
- FollowMultiple object instantiated when a 'Multiple:' prefix detected in filename 
- FollowMultiple object creates a Follower object for each file found that matches pattern (where wildcard is present)
- For shutdown, individual FollowMultiple object will first 'close' all follower objects it is holding 
- FollowMultiple class will be responsible for 'dynamic' tracking of files and for managing the limitation on max number of files followed

_help.sh_
- updated to add new --mutilog option

_README.md_
- updated to include description of usage and example for --multilog    

_Test Files Added_
- multilog_configuration.sh
- multilog_dynamic.sh
- multilog_pathname_verification.sh
- multilog_workflow.sh

_test.sh_
- added new variable for TMP dictionary use on POST urlendcoding

_vars_
- updated for new HOST_MULTILOG_KEY

